### PR TITLE
Fix issues in guessing game

### DIFF
--- a/src/Application.tsx
+++ b/src/Application.tsx
@@ -42,7 +42,7 @@ const Application: FunctionComponent = (): JSX.Element => {
           <GuessingCard>
             <h1 className={"text-3xl"}>
               {
-                guess !== 0 ?
+                tries > 0 ?
                   <GuessComponent />
                   :
                   tries < 10 ?

--- a/src/components/Configurations.tsx
+++ b/src/components/Configurations.tsx
@@ -22,9 +22,9 @@ const Configurations: FunctionComponent = (): JSX.Element => {
         <input
           type="checkbox"
           name="hints"
-          defaultChecked={hints}
+          checked={hints}
           className={styles.check}
-          onClick={handleCheck}
+          onChange={handleCheck}
         />
         <span>Enable Hints</span>
       </div>

--- a/src/components/DifficultyCard.tsx
+++ b/src/components/DifficultyCard.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react";
 import styles from "./../css/difficultycard.module.css";
-import { useDispatch } from "react-redux/es/exports";
+import { useDispatch } from "react-redux";
 import { randomActions } from "../state/reducers/random";
 import DifficultySelector from "./DifficultySelector";
 import { useSelector } from "react-redux";
@@ -9,26 +9,22 @@ import { RootState } from "../state/store";
 const DifficultyCard: FunctionComponent = (): JSX.Element => {
   const dispatch = useDispatch();
 
-  const { number } = useSelector((state: RootState) => state.random);
-
-  React.useEffect(() => {
-    dispatch(randomActions.setDifficulty("EXPERT"));
-  }, []);
+  const { maximum, difficulty } = useSelector((state: RootState) => state.random);
 
   const isEasy = () => {
-    return number > 1 && number < 100;
+    return maximum === difficulty.easy;
   };
 
   const isMedium = () => {
-    return number > 100 && number < 1_000;
+    return maximum === difficulty.medium;
   };
 
   const isHard = () => {
-    return number > 1_000 && number < 100_000;
+    return maximum === difficulty.hard;
   };
 
   const isExpert = () => {
-    return number > 100_000 && number < 1_000_000;
+    return maximum === difficulty.expert;
   };
 
   return (

--- a/src/components/GuessingBox.tsx
+++ b/src/components/GuessingBox.tsx
@@ -11,13 +11,14 @@ const GuessingBox: FunctionComponent = (): JSX.Element => {
   const dispatch = useDispatch();
 
   const isDisabled = () => {
-    return tries >= 10;
+    return tries >= 10 || hasWon;
   };
 
   const handleChange = (event: ChangeEvent) => {
     const { value } = event.target as HTMLInputElement;
+    const numeric = parseInt(value);
 
-    dispatch(setGuess(parseInt(value)));
+    dispatch(setGuess(isNaN(numeric) ? 0 : numeric));
   };
 
   const handleTry = (event: FormEvent) => {
@@ -37,7 +38,7 @@ const GuessingBox: FunctionComponent = (): JSX.Element => {
 
   const GuessButton: FunctionComponent = (): JSX.Element => {
     return (
-      <button type={"submit"} className={`${styles.button} ${isDisabled() ? "bg-gray-300" : null}`}>
+      <button type={"submit"} className={`${styles.button} ${isDisabled() ? "bg-gray-300" : null}`} disabled={isDisabled()}>
         Guess
       </button>
     );
@@ -55,10 +56,11 @@ const GuessingBox: FunctionComponent = (): JSX.Element => {
     <form className={styles.container} onSubmit={handleTry}>
       <input
         type={"number"}
-        defaultValue={guess}
+        value={guess}
         onChange={handleChange}
-        min={1}
+        min={0}
         max={maximum}
+        disabled={isDisabled()}
         className={`${styles.input} ${isDisabled() ? "bg-gray-300" : null}`}
       />
 

--- a/src/state/reducers/random.ts
+++ b/src/state/reducers/random.ts
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const randomize = (maximum: number) => {
-  return Math.floor(Math.random() * maximum);
+  return Math.floor(Math.random() * (maximum + 1));
 };
 
 interface InitialProps {
@@ -84,6 +84,7 @@ const randomSlice = createSlice({
       state.tries = 0;
       state.messages = [];
       state.hasWon = false;
+      state.guess = 0;
     },
     setWon: (state) => {
       state.hasWon = true;


### PR DESCRIPTION
## Summary
- fix inclusive random generation and reset guess on restart
- make hint checkbox controlled
- correct difficulty handling and default
- prevent NaN guesses and disable inputs when game ends
- show guess results after first try

## Testing
- `npm run build` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684136b5d0f08326ac0f53dbf61dd057