### PR TITLE
Fix style issues and small optimizations

### DIFF
--- a/src/components/ColumnSpan.tsx
+++ b/src/components/ColumnSpan.tsx
@@ -7,7 +7,10 @@ interface Props {
 
 const ColumnSpan: FunctionComponent<Props> = ({ columns, children }: Props): JSX.Element => {
   return (
-    <div className={`col-span-${columns} w-full`}>
+    <div
+      className="w-full"
+      style={{ gridColumn: `span ${columns} / span ${columns}` }}
+    >
       {children}
     </div>
   );

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -8,7 +8,10 @@ interface Props {
 
 const Grid: FunctionComponent<Props> = ({ columns, children }: Props): JSX.Element => {
   return (
-    <div className={`grid grid-cols-${columns} ${styles.container}`}>
+    <div
+      className={`grid ${styles.container}`}
+      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+    >
       {children}
     </div>
   );

--- a/src/components/GuessingBox.tsx
+++ b/src/components/GuessingBox.tsx
@@ -10,13 +10,10 @@ const GuessingBox: FunctionComponent = (): JSX.Element => {
 
   const dispatch = useDispatch();
 
-  const isDisabled = () => {
-    return tries >= 10 || hasWon;
-  };
+  const disabled = tries >= 10 || hasWon;
 
-  const handleChange = (event: ChangeEvent) => {
-    const { value } = event.target as HTMLInputElement;
-    const numeric = parseInt(value);
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const numeric = Number(event.target.value);
 
     dispatch(setGuess(isNaN(numeric) ? 0 : numeric));
   };
@@ -38,7 +35,7 @@ const GuessingBox: FunctionComponent = (): JSX.Element => {
 
   const GuessButton: FunctionComponent = (): JSX.Element => {
     return (
-      <button type={"submit"} className={`${styles.button} ${isDisabled() ? "bg-gray-300" : null}`} disabled={isDisabled()}>
+      <button type={"submit"} className={`${styles.button} ${disabled ? "bg-gray-300" : null}`} disabled={disabled}>
         Guess
       </button>
     );
@@ -60,8 +57,8 @@ const GuessingBox: FunctionComponent = (): JSX.Element => {
         onChange={handleChange}
         min={0}
         max={maximum}
-        disabled={isDisabled()}
-        className={`${styles.input} ${isDisabled() ? "bg-gray-300" : null}`}
+        disabled={disabled}
+        className={`${styles.input} ${disabled ? "bg-gray-300" : null}`}
       />
 
       {

--- a/src/components/History.tsx
+++ b/src/components/History.tsx
@@ -14,11 +14,9 @@ const History: FunctionComponent = (): JSX.Element => {
           :
           <ul className={styles.card}>
             {
-              messages.map((message, index) => {
-                return (
-                  <li className={styles.list} key={index}>{message}</li>
-                );
-              })
+              messages.map((message: string) => (
+                <li className={styles.list} key={message}>{message}</li>
+              ))
             }
           </ul>
       }

--- a/src/state/reducers/random.ts
+++ b/src/state/reducers/random.ts
@@ -75,6 +75,9 @@ const randomSlice = createSlice({
     },
     setMessage: (state, { payload }) => {
       state.messages.unshift(payload);
+      if (state.messages.length > 20) {
+        state.messages.pop();
+      }
     },
     setGuess: (state, { payload }) => {
       state.guess = payload;


### PR DESCRIPTION
## Summary
- limit history length in state reducer
- simplify disabled logic in guessing box
- use number parsing and typed events
- use inline styles for dynamic grid and column span
- tighten map key typing for History component

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6841386738388326b246b516dcef4c9b